### PR TITLE
Fix automake on Debian Jessie

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_CANONICAL_SYSTEM
 AC_PREREQ(2.63)
 AC_CONFIG_SRCDIR([src/encoder.c])
 AC_CONFIG_MACRO_DIR([m4])
-AM_INIT_AUTOMAKE([tar-ustar --warnings=no-portability])
+AM_INIT_AUTOMAKE([tar-ustar --warnings=no-portability subdir-objects])
 LT_INIT
 AC_PROG_CC
 AC_CONFIG_HEADERS(config.h)


### PR DESCRIPTION
Hi this small change seems like fixes this issue:
./autogen.sh 
Generating build scripts for G729 codec...
+ libtoolize --copy --force
libtoolize: putting auxiliary files in `.'.
libtoolize: copying file `./ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIR, `m4'.
libtoolize: copying file `m4/libtool.m4'
libtoolize: copying file `m4/ltoptions.m4'
libtoolize: copying file `m4/ltsugar.m4'
libtoolize: copying file `m4/ltversion.m4'
libtoolize: copying file `m4/lt~obsolete.m4'
+ aclocal
+ autoheader
+ automake --force-missing --add-missing --copy
configure.ac:12: installing './compile'
configure.ac:7: installing './config.guess'
configure.ac:7: installing './config.sub'
configure.ac:11: installing './install-sh'
configure.ac:11: installing './missing'
Makefile.am: installing './INSTALL'
msbcg729/Makefile.am: installing './depcomp'
parallel-tests: installing './test-driver'
test/bin/Makefile.am:17: warning: source file '$(top_srcdir)/test/src/CNGRFC3389decoderTest.c' is in a subdirectory,
test/bin/Makefile.am:17: but option 'subdir-objects' is disabled
automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled.  For now, the corresponding output
automake: object file(s) will be placed in the top-level directory.  However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.
test/bin/Makefile.am:4: warning: source file '$(top_srcdir)/test/src/testUtils.c' is in a subdirectory,
test/bin/Makefile.am:4: but option 'subdir-objects' is disabled
test/bin/Makefile.am:18: warning: source file '$(top_srcdir)/test/src/CNGdecoderTest.c' is in a subdirectory,
test/bin/Makefile.am:18: but option 'subdir-objects' is disabled
test/bin/Makefile.am:28: warning: source file '$(top_srcdir)/test/src/LP2LSPConversionTest.c' is in a subdirectory,
test/bin/Makefile.am:28: but option 'subdir-objects' is disabled
test/bin/Makefile.am:29: warning: source file '$(top_srcdir)/test/src/LPSynthesisFilterTest.c' is in a subdirectory,
test/bin/Makefile.am:29: but option 'subdir-objects' is disabled
test/bin/Makefile.am:30: warning: source file '$(top_srcdir)/test/src/LSPQuantizationTest.c' is in a subdirectory,
test/bin/Makefile.am:30: but option 'subdir-objects' is disabled
test/bin/Makefile.am:8: warning: source file '$(top_srcdir)/test/src/adaptativeCodebookSearchTest.c' is in a subdirectory,
test/bin/Makefile.am:8: but option 'subdir-objects' is disabled
test/bin/Makefile.am:9: warning: source file '$(top_srcdir)/test/src/computeAdaptativeCodebookGainTest.c' is in a subdirectory,
test/bin/Makefile.am:9: but option 'subdir-objects' is disabled
test/bin/Makefile.am:10: warning: source file '$(top_srcdir)/test/src/computeLPTest.c' is in a subdirectory,
test/bin/Makefile.am:10: but option 'subdir-objects' is disabled
test/bin/Makefile.am:34: warning: source file '$(top_srcdir)/test/src/computeNoiseExcitationTest.c' is in a subdirectory,
test/bin/Makefile.am:34: but option 'subdir-objects' is disabled
test/bin/Makefile.am:11: warning: source file '$(top_srcdir)/test/src/computeWeightedSpeechTest.c' is in a subdirectory,
test/bin/Makefile.am:11: but option 'subdir-objects' is disabled
test/bin/Makefile.am:12: warning: source file '$(top_srcdir)/test/src/decodeAdaptativeCodeVectorTest.c' is in a subdirectory,
test/bin/Makefile.am:12: but option 'subdir-objects' is disabled
test/bin/Makefile.am:13: warning: source file '$(top_srcdir)/test/src/decodeFixedCodeVectorTest.c' is in a subdirectory,
test/bin/Makefile.am:13: but option 'subdir-objects' is disabled
test/bin/Makefile.am:14: warning: source file '$(top_srcdir)/test/src/decodeGainsTest.c' is in a subdirectory,
test/bin/Makefile.am:14: but option 'subdir-objects' is disabled
test/bin/Makefile.am:15: warning: source file '$(top_srcdir)/test/src/decodeLSPTest.c' is in a subdirectory,
test/bin/Makefile.am:15: but option 'subdir-objects' is disabled
test/bin/Makefile.am:19: warning: source file '$(top_srcdir)/test/src/decoderMultiChannelTest.c' is in a subdirectory,
test/bin/Makefile.am:19: but option 'subdir-objects' is disabled
test/bin/Makefile.am:16: warning: source file '$(top_srcdir)/test/src/decoderTest.c' is in a subdirectory,
test/bin/Makefile.am:16: but option 'subdir-objects' is disabled
test/bin/Makefile.am:21: warning: source file '$(top_srcdir)/test/src/encoderMultiChannelTest.c' is in a subdirectory,
test/bin/Makefile.am:21: but option 'subdir-objects' is disabled
test/bin/Makefile.am:20: warning: source file '$(top_srcdir)/test/src/encoderTest.c' is in a subdirectory,
test/bin/Makefile.am:20: but option 'subdir-objects' is disabled
test/bin/Makefile.am:35: warning: source file '$(top_srcdir)/test/src/encoderVADTest.c' is in a subdirectory,
test/bin/Makefile.am:35: but option 'subdir-objects' is disabled
test/bin/Makefile.am:22: warning: source file '$(top_srcdir)/test/src/findOpenLoopPitchDelayTest.c' is in a subdirectory,
test/bin/Makefile.am:22: but option 'subdir-objects' is disabled
test/bin/Makefile.am:23: warning: source file '$(top_srcdir)/test/src/fixedCodebookSearchTest.c' is in a subdirectory,
test/bin/Makefile.am:23: but option 'subdir-objects' is disabled
test/bin/Makefile.am:24: warning: source file '$(top_srcdir)/test/src/g729FixedPointMathTest.c' is in a subdirectory,
test/bin/Makefile.am:24: but option 'subdir-objects' is disabled
test/bin/Makefile.am:26: warning: source file '$(top_srcdir)/test/src/gainQuantizationTest.c' is in a subdirectory,
test/bin/Makefile.am:26: but option 'subdir-objects' is disabled
test/bin/Makefile.am:27: warning: source file '$(top_srcdir)/test/src/interpolateqLSPAndConvert2LPTest.c' is in a subdirectory,
test/bin/Makefile.am:27: but option 'subdir-objects' is disabled
test/bin/Makefile.am:31: warning: source file '$(top_srcdir)/test/src/postFilterTest.c' is in a subdirectory,
test/bin/Makefile.am:31: but option 'subdir-objects' is disabled
test/bin/Makefile.am:32: warning: source file '$(top_srcdir)/test/src/postProcessingTest.c' is in a subdirectory,
test/bin/Makefile.am:32: but option 'subdir-objects' is disabled
test/bin/Makefile.am:33: warning: source file '$(top_srcdir)/test/src/preProcessingTest.c' is in a subdirectory,
test/bin/Makefile.am:33: but option 'subdir-objects' is disabled
+ autoconf
+ cd /root/mod_bcg729/bcg729
