### PR TITLE
cmake: fix symbol visibility and install pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,19 @@ configure_file(Bcg729Config.cmake.in
 	@ONLY
 )
 
+set(prefix "${CMAKE_INSTALL_PREFIX}")
+set(exec_prefix "\${prefix}")
+set(includedir  "\${prefix}/include")
+set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+configure_file(libbcg729.pc.in
+	"${CMAKE_CURRENT_BINARY_DIR}/libbcg729.pc"
+	@ONLY
+)
+install(FILES
+	"${CMAKE_CURRENT_BINARY_DIR}/libbcg729.pc"
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)
+
 set(CONFIG_PACKAGE_LOCATION "${CMAKE_INSTALL_DATADIR}/Bcg729/cmake")
 install(EXPORT Bcg729Targets
 	FILE Bcg729Targets.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ else()
 	if (NOT IOS)
 		add_definitions("-Werror")
 	endif()
+	add_definitions("-fvisibility=hidden")
 endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)


### PR DESCRIPTION
Patches to improve make the CMake build be similar to CMake:

* cmake: fix symbol visibility
  Avoid exposing unexported symbols, matches autotools behavior.
* CMake: install pkg-config files for parity with autotools

Fixes some of the issues from https://gitlab.linphone.org/BC/public/bcg729/issues/2