### PR TITLE
Handle macOS systems with glibtoolize in /usr/local/bin.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -18,6 +18,9 @@ fi
 if test -f /opt/local/bin/glibtoolize ; then
 	# darwin
 	LIBTOOLIZE=/opt/local/bin/glibtoolize
+elif test -f /usr/local/bin/glibtoolize ; then
+	# also darwin
+	LIBTOOLIZE=/usr/local/bin/glibtoolize
 else
 	LIBTOOLIZE=libtoolize
 fi


### PR DESCRIPTION
Not all such systems have it in /opt/local/bin.