### PR TITLE
Mark input pointer arguments with const

### DIFF
--- a/include/bcg729/decoder.h
+++ b/include/bcg729/decoder.h
@@ -65,5 +65,5 @@ BCG729_VISIBILITY void closeBcg729DecoderChannel(bcg729DecoderChannelContextStru
 /*      -(o) signal : a decoded frame 80 samples (16 bits PCM)               */
 /*                                                                           */
 /*****************************************************************************/
-BCG729_VISIBILITY void bcg729Decoder(bcg729DecoderChannelContextStruct *decoderChannelContext, uint8_t bitStream[], uint8_t bitStreamLength, uint8_t frameErasureFlag, uint8_t SIDFrameFlag, uint8_t rfc3389PayloadFlag, int16_t signal[]);
+BCG729_VISIBILITY void bcg729Decoder(bcg729DecoderChannelContextStruct *decoderChannelContext, const uint8_t bitStream[], uint8_t bitStreamLength, uint8_t frameErasureFlag, uint8_t SIDFrameFlag, uint8_t rfc3389PayloadFlag, int16_t signal[]);
 #endif /* ifndef DECODER_H */

--- a/include/bcg729/encoder.h
+++ b/include/bcg729/encoder.h
@@ -67,7 +67,7 @@ BCG729_VISIBILITY void closeBcg729EncoderChannel(bcg729EncoderChannelContextStru
 /*           if VAD/DTX is enabled                                           */
 /*                                                                           */
 /*****************************************************************************/
-BCG729_VISIBILITY void bcg729Encoder(bcg729EncoderChannelContextStruct *encoderChannelContext, int16_t inputFrame[], uint8_t bitStream[], uint8_t *bitStreamLength);
+BCG729_VISIBILITY void bcg729Encoder(bcg729EncoderChannelContextStruct *encoderChannelContext, const int16_t inputFrame[], uint8_t bitStream[], uint8_t *bitStreamLength);
 
 /*****************************************************************************/
 /* bcg729GetRFC3389Payload : return the comfort noise payload according to   */

--- a/src/cng.c
+++ b/src/cng.c
@@ -242,7 +242,7 @@ void computeComfortNoiseExcitationVector(word16_t targetGain, uint16_t *randomGe
 /*              used to compute the current qLSF                                           */
 /*                                                                                         */
 /*******************************************************************************************/
-void decodeSIDframe(bcg729CNGChannelContextStruct *CNGChannelContext, uint8_t previousFrameIsActiveFlag, uint8_t *bitStream, uint8_t bitStreamLength, word16_t *excitationVector, word16_t *previousqLSP, word16_t *LP, uint16_t *pseudoRandomSeed, word16_t previousLCodeWord[MA_MAX_K][NB_LSP_COEFF], uint8_t rfc3389PayloadFlag) {
+void decodeSIDframe(bcg729CNGChannelContextStruct *CNGChannelContext, uint8_t previousFrameIsActiveFlag, const uint8_t *bitStream, uint8_t bitStreamLength, word16_t *excitationVector, word16_t *previousqLSP, word16_t *LP, uint16_t *pseudoRandomSeed, word16_t previousLCodeWord[MA_MAX_K][NB_LSP_COEFF], uint8_t rfc3389PayloadFlag) {
 	int i;
 	word16_t interpolatedqLSP[NB_LSP_COEFF]; /* interpolated qLSP in Q0.15 */
 	/* if this is a SID frame, decode received parameters */

--- a/src/cng.h
+++ b/src/cng.h
@@ -52,5 +52,5 @@ void computeComfortNoiseExcitationVector(word16_t targetGain, uint16_t *randomGe
 /*      -(i) rfc3389PayloadFlag: true when CN payload follow rfc3389                       */
 /*                                                                                         */
 /*******************************************************************************************/
-void decodeSIDframe(bcg729CNGChannelContextStruct *CNGChannelContext, uint8_t previousFrameIsActiveFlag, uint8_t *bitStream, uint8_t bitStreamLength, word16_t *excitationVector, word16_t *previousqLSP, word16_t *LP, uint16_t *pseudoRandomSeed, word16_t previousLCodeWord[MA_MAX_K][NB_LSP_COEFF], uint8_t rfc3389PayloadFlag);
+void decodeSIDframe(bcg729CNGChannelContextStruct *CNGChannelContext, uint8_t previousFrameIsActiveFlag, const uint8_t *bitStream, uint8_t bitStreamLength, word16_t *excitationVector, word16_t *previousqLSP, word16_t *LP, uint16_t *pseudoRandomSeed, word16_t previousLCodeWord[MA_MAX_K][NB_LSP_COEFF], uint8_t rfc3389PayloadFlag);
 #endif /* ifndef CNG_H */

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -107,7 +107,7 @@ void closeBcg729DecoderChannel(bcg729DecoderChannelContextStruct *decoderChannel
 /*      -(o) signal : a decoded frame 80 samples (16 bits PCM)               */
 /*                                                                           */
 /*****************************************************************************/
-void bcg729Decoder(bcg729DecoderChannelContextStruct *decoderChannelContext, uint8_t bitStream[], uint8_t bitStreamLength, uint8_t frameErasureFlag, uint8_t SIDFrameFlag, uint8_t rfc3389PayloadFlag, int16_t signal[])
+void bcg729Decoder(bcg729DecoderChannelContextStruct *decoderChannelContext, const uint8_t bitStream[], uint8_t bitStreamLength, uint8_t frameErasureFlag, uint8_t SIDFrameFlag, uint8_t rfc3389PayloadFlag, int16_t signal[])
 {
 	int i;
 	uint16_t parameters[NB_PARAMETERS];

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -114,7 +114,7 @@ void closeBcg729EncoderChannel(bcg729EncoderChannelContextStruct *encoderChannel
 /*           on 80 bits (10 8bits words)                                     */
 /*                                                                           */
 /*****************************************************************************/
-void bcg729Encoder(bcg729EncoderChannelContextStruct *encoderChannelContext, int16_t inputFrame[], uint8_t bitStream[], uint8_t *bitStreamLength)
+void bcg729Encoder(bcg729EncoderChannelContextStruct *encoderChannelContext, const int16_t inputFrame[], uint8_t bitStream[], uint8_t *bitStreamLength)
 {
 	int i;
 	uint16_t parameters[NB_PARAMETERS]; /* the output parameters in an array */

--- a/src/preProcessing.c
+++ b/src/preProcessing.c
@@ -65,7 +65,7 @@ void initPreProcessing(bcg729EncoderChannelContextStruct *encoderChannelContext)
 /*      -(o) preProcessedSignal : 80 values in Q0                            */
 /*                                                                           */
 /*****************************************************************************/
-void preProcessing(bcg729EncoderChannelContextStruct *encoderChannelContext, word16_t signal[], word16_t preProcessedSignal[]) {
+void preProcessing(bcg729EncoderChannelContextStruct *encoderChannelContext, const word16_t signal[], word16_t preProcessedSignal[]) {
 	int i;
 	word16_t inputX2;
 	word32_t acc; /* in Q12 */

--- a/src/preProcessing.h
+++ b/src/preProcessing.h
@@ -33,5 +33,5 @@ void initPreProcessing(bcg729EncoderChannelContextStruct *encoderChannelContext)
 /*      -(o) preProcessedSignal : 80 values in Q0                            */
 /*                                                                           */
 /*****************************************************************************/
-void preProcessing(bcg729EncoderChannelContextStruct *encoderChannelContext, word16_t signal[], word16_t preProcessedSignal[]);
+void preProcessing(bcg729EncoderChannelContextStruct *encoderChannelContext, const word16_t signal[], word16_t preProcessedSignal[]);
 #endif /* ifndef PREPROCESSING_H */

--- a/src/utils.c
+++ b/src/utils.c
@@ -347,7 +347,7 @@ void CNGparametersArray2BitStream(uint16_t parameters[], uint8_t bitStream[]) {
 /*      -(o) parameters : 16 values parameters array                         */
 /*                                                                           */
 /*****************************************************************************/
-void parametersBitStream2Array(uint8_t bitStream[], uint16_t parameters[])
+void parametersBitStream2Array(const uint8_t bitStream[], uint16_t parameters[])
 {
 	parameters[0] = (bitStream[0]>>7)&(uint16_t)0x1;
 	parameters[1] = bitStream[0]&(uint16_t)0x7f;

--- a/src/utils.h
+++ b/src/utils.h
@@ -212,7 +212,7 @@ void CNGparametersArray2BitStream(uint16_t parameters[], uint8_t bitStream[]);
 /*      -(o) parameters : 16 values parameters array                         */
 /*                                                                           */
 /*****************************************************************************/
-void parametersBitStream2Array(uint8_t bitStream[], uint16_t parameters[]);
+void parametersBitStream2Array(const uint8_t bitStream[], uint16_t parameters[]);
 
 /*****************************************************************************/
 /* pseudoRandom : generate pseudo random number as in spec 4.4.4 eq96        */


### PR DESCRIPTION
It indicates that the library is not going to modify input data. This helps using the library in C++ projects, where `const` is essential.